### PR TITLE
add default nullhandler to torment logging

### DIFF
--- a/torment/decorators.py
+++ b/torment/decorators.py
@@ -21,6 +21,8 @@ from typing import Any
 from typing import Callable
 
 logger = logging.getLogger(__name__)
+logger.propogate = False
+logger.addHandler(logging.NullHandler())
 
 
 def log(prefix = ''):


### PR DESCRIPTION
This will suppress logging when used by default until another handler is added.