### PR TITLE
drop decorators.log from extend

### DIFF
--- a/torment/helpers.py
+++ b/torment/helpers.py
@@ -29,7 +29,6 @@ from torment import decorators
 logger = logging.getLogger(__name__)
 
 
-@decorators.log
 def extend(base: Dict[Any, Any], extension: Dict[Any, Any]) -> Dict[Any, Any]:
     '''Extend base by updating with the extension.
  


### PR DESCRIPTION
extend can get quite noisy when used properly (reduce a set of
dictionaries into one).  We don't need to know when they start and stop
since there is no debugging output in such a simple function.