### PR TITLE
fix docker-compose calls for shell use

### DIFF
--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/__init__.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/__init__.py
@@ -56,6 +56,22 @@ class UpFixture(CallWrapperFixture):
     def description(self) -> str:
         return super().description[:-1] + '{0.parameters[services]})'.format(self)
 
+
+class ErrorUpFixture(CallWrapperFixture):
+    @property
+    def description(self) -> str:
+        return super().description[:-1] + '{0.parameters[services]}) → {0.error}'.format(self)
+
+    def run(self) -> None:
+        with self.context.assertRaises(self.error.__class__, msg = self.error.args[0]) as error:
+            compose.up(**self.parameters)
+
+        self.exception = error.exception
+
+    def check(self) -> None:
+        self.context.assertEqual(self.exception.args, self.error.args)
+
+
 helpers.import_directory(__name__, os.path.dirname(__file__))
 
 

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/found_8cebc3407ffe4241986481798ab44ced.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/found_8cebc3407ffe4241986481798ab44ced.py
@@ -20,7 +20,7 @@ fixtures.register(globals(), ( CallWrapperFixture, ), {
     'function_name': 'found',
 
     'expected': (
-        ( ( [ 'which', 'docker-compose', ], ), { 'shell': True, }, ),
-        ( ( [ 'docker-compose', 'stop', ], ), { 'shell': True, }, ),
+        ( ( 'which docker-compose', ), { 'shell': True, }, ),
+        ( ( 'docker-compose stop', ), { 'shell': True, }, ),
     ),
 })

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/stop_57d26f0a628243c7bc53ce0669c7db7c.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/stop_57d26f0a628243c7bc53ce0669c7db7c.py
@@ -20,6 +20,6 @@ fixtures.register(globals(), ( CallWrapperFixture, ), {
     'function_name': 'stop',
 
     'expected': (
-        ( ( [ 'docker-compose', 'stop', ], ), { 'shell': True, }, ),
+        ( ( 'docker-compose stop', ), { 'shell': True, }, ),
     ),
 })

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/up_416fd71be52b4d49ad6b217d730d63d9.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/up_416fd71be52b4d49ad6b217d730d63d9.py
@@ -27,6 +27,6 @@ fixtures.register(globals(), ( UpFixture, ), {
     },
 
     'expected': (
-        ( ( [ 'docker-compose', 'up', '-d', '--no-deps', 'foo', 'bar', ], ), dict(), ),
+        ( ( 'docker-compose up -d --no-deps foo bar', ), { 'shell': True, }, ),
     ),
 })

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/up_a161a7ad677f4805b5dcce231ca72d92.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/up_a161a7ad677f4805b5dcce231ca72d92.py
@@ -14,9 +14,9 @@
 
 from torment import fixtures
 
-from test_torment.test_unit.test_contexts.test_docker.test_compose import UpFixture
+from test_torment.test_unit.test_contexts.test_docker.test_compose import ErrorUpFixture
 
-fixtures.register(globals(), ( UpFixture, ), {
+fixtures.register(globals(), ( ErrorUpFixture, ), {
     'function_name': 'up',
 
     'parameters': {
@@ -24,6 +24,11 @@ fixtures.register(globals(), ( UpFixture, ), {
     },
 
     'expected': (
-        ( ( [ 'docker-compose', 'up', '-d', '--no-deps', ], ), {}, ),
+        ( ( 'docker-compose up -d --no-deps', ), {}, ),
     ),
+
+    'error': {
+        'class': ValueError,
+        'args': ( 'empty iterable passed to up(): []', ),
+    },
 })

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/up_b39b1bba819643f493f1403b08623131.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/up_b39b1bba819643f493f1403b08623131.py
@@ -26,6 +26,6 @@ fixtures.register(globals(), ( UpFixture, ), {
     },
 
     'expected': (
-        ( ( [ 'docker-compose', 'up', '-d', '--no-deps', 'foo', ], ), {}, ),
+        ( ( 'docker-compose up -d --no-deps foo', ), { 'shell': True, }, ),
     ),
 })

--- a/torment/contexts/docker/compose.py
+++ b/torment/contexts/docker/compose.py
@@ -35,7 +35,7 @@ def found() -> bool:
 
     '''
 
-    return 0 == _call([ 'which', 'docker-compose', ], shell = True) and 0 == stop()
+    return 0 == _call('which docker-compose', shell = True) and 0 == stop()
 
 
 def stop() -> int:
@@ -48,7 +48,7 @@ def stop() -> int:
 
     '''
 
-    return _call([ 'docker-compose', 'stop', ], shell = True)
+    return _call('docker-compose stop', shell = True)
 
 
 def up(services: Iterable[str] = ()) -> int:
@@ -67,7 +67,12 @@ def up(services: Iterable[str] = ()) -> int:
 
     '''
 
-    return _call([ 'docker-compose', 'up', '-d', '--no-deps', ] + list(services))
+    services = list(services)
+
+    if not len(services):
+        raise ValueError('empty iterable passed to up(): {0}'.format(services))
+
+    return _call('docker-compose up -d --no-deps ' + ' '.join(services), shell = True)
 
 
 def _call(command: str, *args, **kwargs) -> int:


### PR DESCRIPTION
Seems that we over-reacted to a missing shell = True in up and dropped
the appropriate use of strings as the command passed to _call.  This
converts everything back to strings and adds a test for a new error in
up.  If no services are passed, we raise a ValueError.