### PR TITLE
use graft for docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include docs *
+graft docs
 prune docs/_build
 recursive-include test_torment *.py
 include nose.cfg


### PR DESCRIPTION
Using graft is an easier way to ensure we get every source file for
documentation.