### PR TITLE
auto-merge docker_compose_services in MetaContext

### DIFF
--- a/test_torment/test_unit/test_contexts/__init__.py
+++ b/test_torment/test_unit/test_contexts/__init__.py
@@ -56,6 +56,7 @@ class MetaContextGenerateCasesUnitTest(unittest.TestCase):
             '__str__',
             '__subclasshook__',
             '__weakref__',
+            'docker_compose_services',
             'mocks',
             'mocks_mask',
         ]

--- a/torment/contexts/__init__.py
+++ b/torment/contexts/__init__.py
@@ -57,6 +57,8 @@ class MetaContext(type):
         cls.mocks_mask = set().union(getattr(cls, 'mocks_mask', set()), *[ getattr(base, 'mocks_mask', set()) for base in bases ])
         cls.mocks = set().union(getattr(cls, 'mocks', set()), *[ getattr(base, 'mocks', set()) for base in bases ])
 
+        cls.docker_compose_services = set().union(getattr(cls, 'docker_compose_services', set()), *[ getattr(base, 'docker_compose_services', set()) for base in bases ])
+
         def generate_case(fixture: fixtures.Fixture) -> Callable[[Any], None]:
             '''Generate a ``unittest.TestCase`` compatible test method.
 


### PR DESCRIPTION
In order to drop the requirement on specifying a docker_compose_services
in any docker context we can use the MetaContext to auto-merge the
values from all bases.

* fixes #33