### PR TITLE
Log decorator tests

### DIFF
--- a/test_torment/test_unit/test_decorators/__init__.py
+++ b/test_torment/test_unit/test_decorators/__init__.py
@@ -59,7 +59,8 @@ class LogDecoratorFixture(fixtures.Fixture):
         logger.debug('self.mocked_logger.output: %s', self.mocked_logger.output)
 
     def check(self) -> None:
-        self.context.assertEqual(list(filter(lambda _: 'INFO' in _ or 'EXCEPTION' in _, self.mocked_logger.output)), self.expected)
+        for output in filter(lambda _: 'INFO' in _ or 'EXCEPTION' in _, self.mocked_logger.output):
+            self.context.assertTrue(output.startswith(self.expected.pop(0)))
 
 
 class MockDecoratorFixture(fixtures.Fixture):

--- a/test_torment/test_unit/test_decorators/__init__.py
+++ b/test_torment/test_unit/test_decorators/__init__.py
@@ -15,6 +15,7 @@
 import logging
 import os
 import typing  # noqa (use mypy typing)
+import unittest
 
 from torment import contexts
 from torment import fixtures
@@ -44,6 +45,9 @@ class LogDecoratorFixture(fixtures.Fixture):
     def run(self) -> None:
         logger.debug('self.function: %s', self.function)
         logger.debug('hasattr(self.function, __wrapped__): %s', hasattr(self.function, '__wrapped__'))
+
+        if not hasattr(self.context, 'assertLogs'):
+            raise unittest.SkipTest('assertLogs not available—added in python-3.4')
 
         with self.context.assertLogs(decorators.logger, level = logging.DEBUG) as mocked_logger:
             try:

--- a/test_torment/test_unit/test_decorators/log_decorator_0dc23dbae5644e2a805c83076a4e1090.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_0dc23dbae5644e2a805c83076a4e1090.py
@@ -16,25 +16,19 @@ from torment import fixtures
 
 from test_torment.test_unit.test_decorators import LogDecoratorFixture
 
+from torment import decorators
 
-def failure():
-    raise RuntimeError()
+
+class foo(object):
+    @decorators.log
+    def success(self):
+        pass
 
 fixtures.register(globals(), ( LogDecoratorFixture, ), {
-    'function': failure,
+    'function': foo().success,
 
     'expected': [
-        'INFO:torment.decorators:STARTING: failure()',
-        'ERROR:torment.decorators:EXCEPTION: failure()\n'
-        'Traceback (most recent call last):\n'
-        '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
-        'line 65, in wrapper\n'
-        '    return function(*args, **kwargs)\n'
-        '  File '
-        '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py", '
-        'line 21, in failure\n'
-        '    raise RuntimeError()\n'
-        'RuntimeError',
-        'INFO:torment.decorators:STOPPING: failure()'
+        'INFO:torment.decorators:STARTING: foo.success()',
+        'INFO:torment.decorators:STOPPING: foo.success()',
     ],
 })

--- a/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py
@@ -1,0 +1,40 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_decorators import LogDecoratorFixture
+
+
+def failure():
+    raise RuntimeError()
+
+fixtures.register(globals(), ( LogDecoratorFixture, ), {
+    'function': failure,
+
+    'expected': [
+        'INFO:torment.decorators:STARTING: failure()',
+        'ERROR:torment.decorators:EXCEPTION: failure()\n'
+        'Traceback (most recent call last):\n'
+        '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
+        'line 63, in wrapper\n'
+        '    return function(*args, **kwargs)\n'
+        '  File '
+        '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py", '
+        'line 21, in failure\n'
+        '    raise RuntimeError()\n'
+        'RuntimeError',
+        'INFO:torment.decorators:STOPPING: failure()'
+    ],
+})

--- a/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py
@@ -25,16 +25,7 @@ fixtures.register(globals(), ( LogDecoratorFixture, ), {
 
     'expected': [
         'INFO:torment.decorators:STARTING: failure()',
-        'ERROR:torment.decorators:EXCEPTION: failure()\n'
-        'Traceback (most recent call last):\n'
-        '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
-        'line 65, in wrapper\n'
-        '    return function(*args, **kwargs)\n'
-        '  File '
-        '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py", '
-        'line 21, in failure\n'
-        '    raise RuntimeError()\n'
-        'RuntimeError',
+        'ERROR:torment.decorators:EXCEPTION: failure()',
         'INFO:torment.decorators:STOPPING: failure()'
     ],
 })

--- a/test_torment/test_unit/test_decorators/log_decorator_618313139b654df9bd781cdd49959634.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_618313139b654df9bd781cdd49959634.py
@@ -1,0 +1,34 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_decorators import LogDecoratorFixture
+
+
+def success():
+    pass
+
+fixtures.register(globals(), ( LogDecoratorFixture, ), {
+    'function': success,
+
+    'parameters': {
+        'prefix': 'prefix',
+    },
+
+    'expected': [
+        'INFO:torment.decorators:STARTING: prefixsuccess()',
+        'INFO:torment.decorators:STOPPING: prefixsuccess()',
+    ],
+})

--- a/test_torment/test_unit/test_decorators/log_decorator_7c596a03f39a42bfbad6a8fa191bf021.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_7c596a03f39a42bfbad6a8fa191bf021.py
@@ -17,24 +17,15 @@ from torment import fixtures
 from test_torment.test_unit.test_decorators import LogDecoratorFixture
 
 
-def failure():
-    raise RuntimeError()
+class foo(object):
+    def success(self):
+        pass
 
 fixtures.register(globals(), ( LogDecoratorFixture, ), {
-    'function': failure,
+    'function': foo().success,
 
     'expected': [
-        'INFO:torment.decorators:STARTING: failure()',
-        'ERROR:torment.decorators:EXCEPTION: failure()\n'
-        'Traceback (most recent call last):\n'
-        '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
-        'line 65, in wrapper\n'
-        '    return function(*args, **kwargs)\n'
-        '  File '
-        '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_13d6c3fc82334900a2f294735600931c.py", '
-        'line 21, in failure\n'
-        '    raise RuntimeError()\n'
-        'RuntimeError',
-        'INFO:torment.decorators:STOPPING: failure()'
+        'INFO:torment.decorators:STARTING: foo.success()',
+        'INFO:torment.decorators:STOPPING: foo.success()',
     ],
 })

--- a/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_decorators import LogDecoratorFixture
+
+
+def failure():
+    raise RuntimeError()
+
+fixtures.register(globals(), ( LogDecoratorFixture, ), {
+    'function': failure,
+
+    'parameters': {
+        'prefix': 'prefix',
+    },
+
+    'expected': [
+        'INFO:torment.decorators:STARTING: prefixfailure()',
+        'ERROR:torment.decorators:EXCEPTION: prefixfailure()\n'
+        'Traceback (most recent call last):\n'
+        '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
+        'line 63, in wrapper\n'
+        '    return function(*args, **kwargs)\n'
+        '  File '
+        '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py", '
+        'line 21, in failure\n'
+        '    raise RuntimeError()\n'
+        'RuntimeError',
+        'INFO:torment.decorators:STOPPING: prefixfailure()',
+    ]
+})

--- a/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py
@@ -29,16 +29,7 @@ fixtures.register(globals(), ( LogDecoratorFixture, ), {
 
     'expected': [
         'INFO:torment.decorators:STARTING: prefixfailure()',
-        'ERROR:torment.decorators:EXCEPTION: prefixfailure()\n'
-        'Traceback (most recent call last):\n'
-        '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
-        'line 65, in wrapper\n'
-        '    return function(*args, **kwargs)\n'
-        '  File '
-        '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py", '
-        'line 21, in failure\n'
-        '    raise RuntimeError()\n'
-        'RuntimeError',
+        'ERROR:torment.decorators:EXCEPTION: prefixfailure()',
         'INFO:torment.decorators:STOPPING: prefixfailure()',
     ]
 })

--- a/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py
@@ -32,7 +32,7 @@ fixtures.register(globals(), ( LogDecoratorFixture, ), {
         'ERROR:torment.decorators:EXCEPTION: prefixfailure()\n'
         'Traceback (most recent call last):\n'
         '  File "/home/alunduil/Projects/kumoru/torment/torment/decorators.py", '
-        'line 63, in wrapper\n'
+        'line 65, in wrapper\n'
         '    return function(*args, **kwargs)\n'
         '  File '
         '"/home/alunduil/Projects/kumoru/torment/test_torment/test_unit/test_decorators/log_decorator_af21ed4f310b4148a29697cb1383622f.py", '

--- a/test_torment/test_unit/test_decorators/log_decorator_d4871a3be545479788eac58211d9b14f.py
+++ b/test_torment/test_unit/test_decorators/log_decorator_d4871a3be545479788eac58211d9b14f.py
@@ -1,0 +1,30 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_decorators import LogDecoratorFixture
+
+
+def success():
+    pass
+
+fixtures.register(globals(), ( LogDecoratorFixture, ), {
+    'function': success,
+
+    'expected': [
+        'INFO:torment.decorators:STARTING: success()',
+        'INFO:torment.decorators:STOPPING: success()',
+    ],
+})

--- a/torment/decorators.py
+++ b/torment/decorators.py
@@ -45,7 +45,7 @@ def log(prefix = ''):
         def wrapper(*args, **kwargs):
             name = function.__name__
 
-            if inspect.isclass(args[0]):
+            if len(args) and inspect.isclass(args[0]):
                 members = inspect.getmembers(args[0], predicate = lambda name, value: name == function.__name__)
                 logger.debug('members: %s', members)
 

--- a/torment/decorators.py
+++ b/torment/decorators.py
@@ -43,18 +43,20 @@ def log(prefix = ''):
     def _(function):
         @functools.wraps(function, assigned = functools.WRAPPER_ASSIGNMENTS + ( '__file__', ))
         def wrapper(*args, **kwargs):
-            name = function.__name__
+            name, my_args = function.__name__, args
 
-            if len(args) and inspect.isclass(args[0]):
-                members = inspect.getmembers(args[0], predicate = lambda name, value: name == function.__name__)
+            if inspect.ismethod(function):
+                name = function.__self__.__class__.__name__ + '.' + function.__name__
+            elif len(args):
+                members = dict(inspect.getmembers(args[0], predicate = lambda _: inspect.ismethod(_) and _.__name__ == function.__name__))
                 logger.debug('members: %s', members)
 
                 if len(members):
-                    name = args.pop(0).__class__.__name__ + '.' + function.__name__
+                    name, my_args = args[0].__class__.__name__ + '.' + function.__name__, args[1:]
 
             format_args = (
                 prefix + name,
-                ', '.join(list(map(str, args)) + [ ' = '.join(map(str, item)) for item in kwargs.items() ]),
+                ', '.join(list(map(str, my_args)) + [ ' = '.join(map(str, item)) for item in kwargs.items() ]),
             )
 
             logger.info('STARTING: %s(%s)', *format_args)


### PR DESCRIPTION
This adds tests for the log decorator (leading the way for mock decorator tests) as well as ensures that the class re-write code is working properly.  It was not.  Let me know if the last two commits should be merged but I'm willing to leave them as is.