### PR TITLE
add powerset helper

### DIFF
--- a/test_torment/test_unit/test_helpers/__init__.py
+++ b/test_torment/test_unit/test_helpers/__init__.py
@@ -26,10 +26,22 @@ from torment import helpers
 class ExtendFixture(fixtures.Fixture):
     @property
     def description(self) -> str:
-        return '{0.uuid.hex}—{1}.extend({{ {0.parameters[base]} }}, {{ {0.parameters[extension]} }}) == {{ {0.expected} }}'.format(self, self.context.module)
+        return super().description + '.extend({{ {0.parameters[base]} }}, {{ {0.parameters[extension]} }}) == {{ {0.expected} }}'.format(self)
 
     def run(self) -> None:
         self.result = helpers.extend(self.parameters['base'], self.parameters['extension'])
+
+    def check(self) -> None:
+        self.context.assertEqual(self.expected, self.result)
+
+
+class PowersetFixture(fixtures.Fixture):
+    @property
+    def description(self) -> str:
+        return super().description + '.powerset({0.parameters[iterable]}) == {0.expected}'.format(self)
+
+    def run(self) -> None:
+        self.result = list(helpers.powerset(self.parameters['iterable']))
 
     def check(self) -> None:
         self.context.assertEqual(self.expected, self.result)
@@ -40,6 +52,7 @@ helpers.import_directory(__name__, os.path.dirname(__file__))
 class HelperUnitTest(contexts.TestContext, metaclass = contexts.MetaContext):
     fixture_classes = (
         ExtendFixture,
+        PowersetFixture,
     )
 
 

--- a/test_torment/test_unit/test_helpers/powerset_2089396395d84f8cb502ba0fbb111221.py
+++ b/test_torment/test_unit/test_helpers/powerset_2089396395d84f8cb502ba0fbb111221.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_helpers import PowersetFixture
+
+fixtures.register(globals(), ( PowersetFixture, ), {
+    'parameters': {
+        'iterable': [ 1, ],
+    },
+
+    'expected': [ (), ( 1, ), ],
+})

--- a/test_torment/test_unit/test_helpers/powerset_440a3db60f374794aa60c12dcca01353.py
+++ b/test_torment/test_unit/test_helpers/powerset_440a3db60f374794aa60c12dcca01353.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_helpers import PowersetFixture
+
+fixtures.register(globals(), ( PowersetFixture, ), {
+    'parameters': {
+        'iterable': [],
+    },
+
+    'expected': [ (), ],
+})

--- a/test_torment/test_unit/test_helpers/powerset_713659fc48fd484fa0f5880ff3ef5df3.py
+++ b/test_torment/test_unit/test_helpers/powerset_713659fc48fd484fa0f5880ff3ef5df3.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Alex Brandt
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torment import fixtures
+
+from test_torment.test_unit.test_helpers import PowersetFixture
+
+fixtures.register(globals(), ( PowersetFixture, ), {
+    'parameters': {
+        'iterable': [ 1, 2, ],
+    },
+
+    'expected': [ (), ( 1, ), ( 2, ), ( 1, 2, ), ],
+})

--- a/torment/helpers.py
+++ b/torment/helpers.py
@@ -79,6 +79,23 @@ def import_directory(module_basename: str, directory: str, sort_key = None) -> N
             logger.info('successfully loaded %s', modulename)
 
 
+def powerset(iterable: Iterable[Any]) -> Iterable[Iterable[Any]]:
+    '''Powerset of iterable.
+
+    **Parameters**
+
+    :``iterable``: set to generate powerset
+
+    **Return Value(s)**
+
+    Generator that produces all subsets of iterable.
+
+    '''
+
+    s = list(iterable)
+    return itertools.chain.from_iterable(itertools.combinations(s, r) for r in range(len(s) + 1))
+
+
 @decorators.log
 def _filenames_to_modulenames(filenames: Iterable[str], modulename_prefix: str, filename_prefix: str = '') -> Iterable[str]:
     '''Convert given filenames to module names.


### PR DESCRIPTION
It's convenient to have a method for generating the powerset of an
iterable when generating fixtures.