### PR TITLE
move is_mocked_ to a private property

### DIFF
--- a/test_torment/test_unit/test_decorators/__init__.py
+++ b/test_torment/test_unit/test_decorators/__init__.py
@@ -87,14 +87,14 @@ class MockDecoratorTest(unittest.TestCase):
 
         self.assertFalse(decorators.mock('foo')(lambda self: None)(self.c))
 
-        self.assertFalse(self.c.is_mocked_foo)
+        self.assertFalse(self.c._is_mocked_foo)
 
     def test_single_call(self) -> None:
         '''torment.decorators.mock(foo): not called'''
 
         self.assertTrue(decorators.mock('foo')(lambda self: None)(self.c))
 
-        self.assertTrue(self.c.is_mocked_foo)
+        self.assertTrue(self.c._is_mocked_foo)
 
     def test_many_call(self) -> None:
         '''torment.decorators.mock(foo): previously called'''
@@ -105,4 +105,4 @@ class MockDecoratorTest(unittest.TestCase):
 
         logger.debug('dir(self.c): %s', dir(self.c))
 
-        self.assertTrue(self.c.is_mocked_foo)
+        self.assertTrue(self.c._is_mocked_foo)

--- a/torment/decorators.py
+++ b/torment/decorators.py
@@ -108,7 +108,7 @@ def mock(name: str) -> Callable[[Any], None]:
 
             if name in self.mocks_mask:
                 logger.info('STOPPING: mock ' + name + '—MASKED')
-            elif getattr(self, 'is_mocked_' + sanitized_name, False):
+            elif getattr(self, '_is_mocked_' + sanitized_name, False):
                 is_mocked = True
 
                 logger.info('STOPPING: mock ' + name + '—EXISTS')
@@ -119,7 +119,7 @@ def mock(name: str) -> Callable[[Any], None]:
 
                 logger.info('STOPPING: mock ' + name)
 
-            setattr(self, 'is_mocked_' + sanitized_name, is_mocked)
+            setattr(self, '_is_mocked_' + sanitized_name, is_mocked)
 
             return is_mocked
 


### PR DESCRIPTION
We don't want to encourage the use of this book keeping property by
users and are privatizing it.  This will necessitate a new major
revision.

* fixes #21