### PR TITLE
only log members' keys

### DIFF
--- a/torment/decorators.py
+++ b/torment/decorators.py
@@ -49,7 +49,7 @@ def log(prefix = ''):
                 name = function.__self__.__class__.__name__ + '.' + function.__name__
             elif len(args):
                 members = dict(inspect.getmembers(args[0], predicate = lambda _: inspect.ismethod(_) and _.__name__ == function.__name__))
-                logger.debug('members: %s', members)
+                logger.debug('members.keys(): %s', members.keys())
 
                 if len(members):
                     name, my_args = args[0].__class__.__name__ + '.' + function.__name__, args[1:]


### PR DESCRIPTION
After seeing this in action, I'm pleased but the members logging is too
verbose.  This should clean it up and make it useful in the event it's
needed.