### PR TITLE
remove no deps to enable docker links

### DIFF
--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/up_416fd71be52b4d49ad6b217d730d63d9.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/up_416fd71be52b4d49ad6b217d730d63d9.py
@@ -27,6 +27,6 @@ fixtures.register(globals(), ( UpFixture, ), {
     },
 
     'expected': (
-        ( ( 'docker-compose up --no-color -d --no-deps foo bar', ), { 'shell': True, }, ),
+        ( ( 'docker-compose up --no-color -d foo bar', ), { 'shell': True, }, ),
     ),
 })

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/up_a161a7ad677f4805b5dcce231ca72d92.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/up_a161a7ad677f4805b5dcce231ca72d92.py
@@ -24,7 +24,7 @@ fixtures.register(globals(), ( ErrorUpFixture, ), {
     },
 
     'expected': (
-        ( ( 'docker-compose up -d --no-deps', ), {}, ),
+        ( ( 'docker-compose up -d ', ), {}, ),
     ),
 
     'error': {

--- a/test_torment/test_unit/test_contexts/test_docker/test_compose/up_b39b1bba819643f493f1403b08623131.py
+++ b/test_torment/test_unit/test_contexts/test_docker/test_compose/up_b39b1bba819643f493f1403b08623131.py
@@ -26,6 +26,6 @@ fixtures.register(globals(), ( UpFixture, ), {
     },
 
     'expected': (
-        ( ( 'docker-compose up --no-color -d --no-deps foo', ), { 'shell': True, }, ),
+        ( ( 'docker-compose up --no-color -d foo', ), { 'shell': True, }, ),
     ),
 })

--- a/torment/contexts/docker/compose.py
+++ b/torment/contexts/docker/compose.py
@@ -72,7 +72,7 @@ def up(services: Iterable[str] = ()) -> int:
     if not len(services):
         raise ValueError('empty iterable passed to up(): {0}'.format(services))
 
-    return _call('docker-compose up --no-color -d --no-deps ' + ' '.join(services), shell = True)
+    return _call('docker-compose up --no-color -d ' + ' '.join(services), shell = True)
 
 
 def _call(command: str, *args, **kwargs) -> int:


### PR DESCRIPTION
By removing --no-deps in the docker-compose up command we effectively start all docker services that have links defined in their docker-compose.yml. This commit solves issue #84. 